### PR TITLE
Add script to invoke happycommit program

### DIFF
--- a/git-commit-gpt
+++ b/git-commit-gpt
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Invoke the happycommit program
+happycommit "$@"


### PR DESCRIPTION
This commit adds a Bash script called git-commit-gpt to invoke the happycommit program. The script takes in any arguments passed to it and passes them along to the happycommit program.

The purpose of this script is to simplify the process of invoking the happycommit program, which can be a bit confusing for some users. By using the script, users can simply run "git-commit-gpt" instead of having to remember the exact command to invoke the happycommit program.

No automated testing was added, however this commit was written using `git commit-gpt` so SOMETHING worked right :-)

Note: The script was added to the staged workspace as an executable file with permissions set to 100644. The script is turned into an executable by a different script that installs it.